### PR TITLE
Search horizontal loading state

### DIFF
--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -5,18 +5,22 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
 
-	<LinearLayout
-		android:id="@android:id/progress"
+	<FrameLayout
 		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:gravity="center"
-		android:orientation="vertical">
+		android:layout_height="@dimen/material_progress_bar_height">
+
+		<!-- External FrameLayout required to clip
+		ProgressBar top and bottom asset spacing. -->
 
 		<ProgressBar
-			style="?android:attr/progressBarStyleLarge"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"/>
-	</LinearLayout>
+			android:id="@android:id/progress"
+			style="?android:attr/progressBarStyleHorizontal"
+			android:layout_width="match_parent"
+			android:layout_height="@dimen/material_progress_bar_unclipped_height"
+			android:layout_gravity="center"
+			android:indeterminate="true"/>
+
+	</FrameLayout>
 
 	<TextView
 		android:id="@android:id/empty"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -58,5 +58,7 @@
 	<dimen name="pad_button_size">48dp</dimen>
 	<dimen name="dialog_width">320dp</dimen>
 	<dimen name="progress_bar_height">8dp</dimen>
+	<dimen name="material_progress_bar_height">4dp</dimen>
+	<dimen name="material_progress_bar_unclipped_height">24dp</dimen>
 
 </resources>


### PR DESCRIPTION
Updated search screen loading state from an inline spinning style to an horizontal style. This fixes the loading state overlapping with search screen content.

Ideally the progress bar should sit above the action bar shadow, but that would require a big refactoring that is probably not worth undertaking. If there's an easy way to achieve it please call it out. 😄 

Results:
![search-progress-1](https://user-images.githubusercontent.com/12709263/41157002-8360bf9a-6b67-11e8-8f6e-9d0447788fa1.png)
![search-progress-2](https://user-images.githubusercontent.com/12709263/41157004-84cca52e-6b67-11e8-9e9f-05864fbbe819.png)
![search-progress-3](https://user-images.githubusercontent.com/12709263/41157007-85f25fd4-6b67-11e8-9794-c4b2880be9f9.png)
