### PR TITLE
Add Sort by Total Time Played

### DIFF
--- a/app/src/main/java/com/boardgamegeek/provider/BggContract.java
+++ b/app/src/main/java/com/boardgamegeek/provider/BggContract.java
@@ -34,6 +34,7 @@ public class BggContract {
 		String MIN_PLAYERS = "min_players";
 		String MAX_PLAYERS = "max_players";
 		String PLAYING_TIME = "playing_time";
+		String PLAYED_TIME = "played_time";
 		String MIN_PLAYING_TIME = "min_playing_time";
 		String MAX_PLAYING_TIME = "max_playing_time";
 		String NUM_PLAYS = "num_of_plays";

--- a/app/src/main/java/com/boardgamegeek/sorter/CollectionSorterFactory.kt
+++ b/app/src/main/java/com/boardgamegeek/sorter/CollectionSorterFactory.kt
@@ -21,6 +21,8 @@ class CollectionSorterFactory(context: Context) {
             add(AverageWeightDescendingSorter(context))
             add(PlayCountAscendingSorter(context))
             add(PlayCountDescendingSorter(context))
+            add(TotalTimePlayedAscendingSorter(context))
+            add(TotalTimePlayedDescendingSorter(context))
             add(LastPlayDateDescendingSorter(context))
             add(LastPlayDateAscendingSorter(context))
             add(WishlistPrioritySorter(context))

--- a/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedAscendingSorter.kt
+++ b/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedAscendingSorter.kt
@@ -1,0 +1,17 @@
+package com.boardgamegeek.sorter
+
+import android.content.Context
+import android.support.annotation.StringRes
+
+import com.boardgamegeek.R
+
+class TotalTimePlayedAscendingSorter(context: Context) : TotalTimePlayedSorter(context) {
+
+    public override val typeResource: Int
+        @StringRes
+        get() = R.string.collection_sort_type_total_played_time_asc
+
+    public override val subDescriptionId: Int
+        @StringRes
+        get() = R.string.shortest
+}

--- a/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedDescendingSorter.kt
+++ b/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedDescendingSorter.kt
@@ -1,0 +1,20 @@
+package com.boardgamegeek.sorter
+
+import android.content.Context
+import android.support.annotation.StringRes
+
+import com.boardgamegeek.R
+
+class TotalTimePlayedDescendingSorter(context: Context) : TotalTimePlayedSorter(context) {
+
+    public override val typeResource: Int
+        @StringRes
+        get() = R.string.collection_sort_type_total_played_time_desc
+
+    override val isSortDescending: Boolean
+        get() = true
+
+    public override val subDescriptionId: Int
+        @StringRes
+        get() = R.string.longest
+}

--- a/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedSorter.kt
+++ b/app/src/main/java/com/boardgamegeek/sorter/TotalTimePlayedSorter.kt
@@ -1,0 +1,38 @@
+package com.boardgamegeek.sorter
+
+import android.content.Context
+import android.database.Cursor
+import android.support.annotation.StringRes
+
+import com.boardgamegeek.R
+import com.boardgamegeek.extensions.getInt
+import com.boardgamegeek.provider.BggContract.Collection
+import com.boardgamegeek.util.PresentationUtils
+
+abstract class TotalTimePlayedSorter(context: Context) : CollectionSorter(context) {
+    private val defaultValue = context.resources.getString(R.string.text_unknown)
+
+    override val descriptionId: Int
+        @StringRes
+        get() = R.string.collection_sort_total_time_played
+
+    override val sortColumn: String
+        get() = Collection.PLAYED_TIME
+
+    public override fun getHeaderText(cursor: Cursor): String {
+        val minutes = cursor.getInt(Collection.PLAYED_TIME)
+        if (minutes == 0) return defaultValue
+
+        return if (minutes >= 120) {
+            val hours = minutes / 60
+            "$hours ${context.getString(R.string.hours_abbr)}"
+        } else {
+            "$minutes ${context.getString(R.string.minutes_abbr)}"
+        }
+    }
+
+    override fun getDisplayInfo(cursor: Cursor): String {
+        val minutes = cursor.getInt(Collection.PLAYED_TIME)
+        return PresentationUtils.describeMinutes(context, minutes).toString()
+    }
+}

--- a/app/src/main/java/com/boardgamegeek/ui/dialog/CollectionSortDialogFragment.java
+++ b/app/src/main/java/com/boardgamegeek/ui/dialog/CollectionSortDialogFragment.java
@@ -51,6 +51,8 @@ public class CollectionSortDialogFragment extends DialogFragment implements OnCh
 		R.id.wishlist_priority,
 		R.id.play_count_asc,
 		R.id.play_count_desc,
+		R.id.total_played_time_asc,
+		R.id.total_played_time_desc,
 		R.id.play_date_max,
 		R.id.play_date_min,
 		R.id.year_published_asc,

--- a/app/src/main/res/layout/dialog_collection_sort.xml
+++ b/app/src/main/res/layout/dialog_collection_sort.xml
@@ -49,6 +49,20 @@
 			android:tag="@string/collection_sort_type_play_count_asc"/>
 
 		<RadioButton
+			android:id="@+id/total_played_time_asc"
+			style="@style/DialogRadioButton"
+			android:layout_width="wrap_content"
+			android:layout_height="match_parent"
+			android:tag="@string/collection_sort_type_total_played_time_asc"/>
+
+		<RadioButton
+			android:id="@+id/total_played_time_desc"
+			style="@style/DialogRadioButton"
+			android:layout_width="wrap_content"
+			android:layout_height="match_parent"
+			android:tag="@string/collection_sort_type_total_played_time_desc"/>
+
+		<RadioButton
 			android:id="@+id/play_date_max"
 			style="@style/DialogRadioButton"
 			android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings-provider.xml
+++ b/app/src/main/res/values/strings-provider.xml
@@ -26,6 +26,8 @@
 	<string name="collection_sort_type_current_value">21</string>
 	<string name="collection_sort_type_play_date_max">22</string>
 	<string name="collection_sort_type_play_date_min">23</string>
+	<string name="collection_sort_type_total_played_time_asc">24</string>
+	<string name="collection_sort_type_total_played_time_desc">25</string>
 
 	<string name="collection_filter_type_collection_status">1</string>
 	<string name="collection_filter_type_subtype">10</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,6 +329,7 @@
 	<string name="collection_sort_play_date_max">Most Recently Played</string>
 	<string name="collection_sort_play_date_min">Least Recently Played</string>
 	<string name="collection_sort_play_time">Play Time</string>
+	<string name="collection_sort_total_time_played">Total Time Played</string>
 	<string name="collection_sort_rank">Rank</string>
 	<string name="collection_sort_suggested_age">Suggested Minimum Age</string>
 	<string name="collection_sort_wishlist_priority">Wishlist Priority</string>


### PR DESCRIPTION
This changeset adds a Sorter by total time played. It is mostly functional, the only thing missing is where to source the  "total time played". I know it is available in `GamePlayStatsFragment`, but dunno how to access or make it available on the sorter.

@ccomeaux if you can help me out with that, I can make this functional!