### PR TITLE
Add get Location support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:16.0.1'
     implementation 'com.google.firebase:firebase-config:16.0.0'
     implementation 'com.google.firebase:firebase-messaging:17.1.0'
+    implementation 'com.google.android.gms:play-services-location:15.0.1'
 
     implementation 'com.google.code.gson:gson:2.8.5'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
 	<uses-permission android:name="android.permission.READ_SYNC_STATS"/>
 	<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 	<uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
 
 	<application

--- a/app/src/main/res/layout/row_log_play_location.xml
+++ b/app/src/main/res/layout/row_log_play_location.xml
@@ -24,4 +24,11 @@
 		android:inputType="textCapWords"
 		android:textAppearance="@style/Text.Big"
 		android:textColor="#000"/>
+
+	<ImageView
+		android:id="@+id/log_play_location_get_current"
+		style="@style/Icon"
+		android:contentDescription="@string/current_location"
+		android:clickable="true"
+		android:src="@drawable/ic_location"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
 	<string name="length_hint">Length in minutes</string>
 	<string name="no_length">\?</string>
 	<string name="location">Location</string>
+	<string name="current_location">Use Current Location</string>
 	<string name="location_hint">Location</string>
 	<string name="no_location">&lt;No location&gt;</string>
 	<string name="nowhere_in_angle_brackets">&lt;Nowhere&gt;</string>


### PR DESCRIPTION
This first version allows user to fill up the location field in the play logging by clicking a new button, that will automatically insert the city he's in, as long as the permission is granted.

As seen [here on Trello](https://trello.com/c/yEn0P0tI/150-capture-the-actual-location)

Some _TODO_ notes:
1. I didn't really know how to request the permission from the `Activity`, I saw there is some support within the `DataFragment.java`.
2. I reused the location icon, for now, because I don't know where you source them from. Thought it was from the material design library provided by Google, but they don't have the same resolutions that the app has in the folder.