### PR TITLE
Fix expansions location

### DIFF
--- a/app/src/main/java/com/boardgamegeek/ui/GameCreditsFragment.kt
+++ b/app/src/main/java/com/boardgamegeek/ui/GameCreditsFragment.kt
@@ -66,10 +66,6 @@ class GameCreditsFragment : Fragment() {
             viewModel.categories.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_categories) })
 
             viewModel.mechanics.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_mechanics) })
-
-            viewModel.expansions.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_expansions) })
-
-            viewModel.baseGames.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_base_games) })
         })
     }
 
@@ -84,7 +80,7 @@ class GameCreditsFragment : Fragment() {
     private fun colorize(@ColorInt iconColor: Int) {
         if (!isAdded) return
 
-        listOf(game_info_designers, game_info_artists, game_info_publishers, game_info_categories, game_info_mechanics, game_info_expansions, game_info_base_games)
+        listOf(game_info_designers, game_info_artists, game_info_publishers, game_info_categories, game_info_mechanics)
                 .forEach { it?.colorize(iconColor) }
     }
 

--- a/app/src/main/java/com/boardgamegeek/ui/GameFragment.kt
+++ b/app/src/main/java/com/boardgamegeek/ui/GameFragment.kt
@@ -121,6 +121,9 @@ class GameFragment : Fragment(R.layout.fragment_game) {
 
         listOf(ranksIcon, ratingIcon, yearIcon, playTimeIcon, playerCountIcon, playerAgeIcon, weightIcon, languageIcon)
                 .forEach { it?.setOrClearColorFilter(iconColor) }
+
+        listOf(game_info_expansions, game_info_base_games)
+                .forEach { it?.colorize(iconColor) }
     }
 
     private fun onGameContentChanged(game: GameEntity) {

--- a/app/src/main/java/com/boardgamegeek/ui/GameFragment.kt
+++ b/app/src/main/java/com/boardgamegeek/ui/GameFragment.kt
@@ -15,6 +15,7 @@ import com.boardgamegeek.provider.BggContract
 import com.boardgamegeek.provider.BggContract.Games
 import com.boardgamegeek.ui.dialog.GameRanksFragment
 import com.boardgamegeek.ui.viewmodel.GameViewModel
+import com.boardgamegeek.ui.widget.GameDetailRow
 import com.boardgamegeek.ui.widget.SafeViewTarget
 import com.boardgamegeek.util.HelpUtils
 import com.boardgamegeek.util.ShowcaseViewWizard
@@ -76,6 +77,10 @@ class GameFragment : Fragment(R.layout.fragment_game) {
             viewModel.agePoll.observe(this, Observer { gameSuggestedAgePollEntity -> onAgePollQueryComplete(gameSuggestedAgePollEntity) })
 
             viewModel.playerPoll.observe(this, Observer { gamePlayerPollEntities -> onPlayerCountQueryComplete(gamePlayerPollEntities) })
+
+            viewModel.expansions.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_expansions) })
+
+            viewModel.baseGames.observe(this, Observer { gameDetails -> onListQueryComplete(gameDetails, game_info_base_games) })
         })
 
         showcaseViewWizard = setUpShowcaseViewWizard()
@@ -209,6 +214,13 @@ class GameFragment : Fragment(R.layout.fragment_game) {
         playerCountContainer?.setOrClearOnClickListener(entity?.totalVotes ?: 0 > 0) {
             SuggestedPlayerCountPollFragment.launch(this)
         }
+    }
+
+    private fun onListQueryComplete(list: List<GameDetailEntity>?, view: GameDetailRow?) {
+        view?.bindData(
+                viewModel.gameId.value ?: BggContract.INVALID_ID,
+                viewModel.game.value?.data?.name ?: "",
+                list)
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -92,6 +92,24 @@
 						layout="@layout/include_game_language_dependence"
 						android:layout_width="match_parent"
 						android:layout_height="wrap_content"/>
+
+					<com.boardgamegeek.ui.widget.GameDetailRow
+						android:id="@+id/game_info_expansions"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:minHeight="@dimen/card_row_height"
+						bgg:icon_res="@drawable/ic_expansions"
+						bgg:label="@string/expansions"
+						bgg:query_token="@integer/query_token_expansions"/>
+
+					<com.boardgamegeek.ui.widget.GameDetailRow
+						android:id="@+id/game_info_base_games"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:minHeight="@dimen/card_row_height"
+						bgg:icon_res="@drawable/ic_basegames"
+						bgg:label="@string/base_games"
+						bgg:query_token="@integer/query_token_base_games"/>
 				</LinearLayout>
 
 				<include layout="@layout/include_game_footer"/>

--- a/app/src/main/res/layout/fragment_game_credits.xml
+++ b/app/src/main/res/layout/fragment_game_credits.xml
@@ -97,24 +97,6 @@
 						bgg:icon_res="@drawable/ic_mechanics"
 						bgg:label="@string/mechanics"
 						bgg:query_token="@integer/query_token_mechanics"/>
-
-					<com.boardgamegeek.ui.widget.GameDetailRow
-						android:id="@+id/game_info_expansions"
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:minHeight="@dimen/card_row_height"
-						bgg:icon_res="@drawable/ic_expansions"
-						bgg:label="@string/expansions"
-						bgg:query_token="@integer/query_token_expansions"/>
-
-					<com.boardgamegeek.ui.widget.GameDetailRow
-						android:id="@+id/game_info_base_games"
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:minHeight="@dimen/card_row_height"
-						bgg:icon_res="@drawable/ic_basegames"
-						bgg:label="@string/base_games"
-						bgg:query_token="@integer/query_token_base_games"/>
 				</LinearLayout>
 
 				<include layout="@layout/include_game_footer"/>


### PR DESCRIPTION
I think expansions should be in _Info_ tab instead of  _Descr_ tab.

Open points (unclear or with need for help):
- [ ] is it okay to add `com.boardgamegeek.ui.widget.GameDetailRow` into `fragment_game.xml` or it should be extracted to separate file like other included layouts above?
- [ ] `onListQueryComplete` method is now duplicated, should I extract it to some common class?
- [ ] colour of the icon for extensions doesn't match other icons on the _Info_ tab (it's gray instead of blue-ish), is there a setting to make the colour align?