### PR TITLE
Don't reset all aspects of the collection view

### DIFF
--- a/app/src/main/java/com/boardgamegeek/ui/CollectionFragment.java
+++ b/app/src/main/java/com/boardgamegeek/ui/CollectionFragment.java
@@ -762,9 +762,10 @@ public class CollectionFragment extends Fragment implements
 		if (viewId != 0) {
 			viewId = 0;
 			viewName = "";
+
+			filters.clear();
+			sorter = getCollectionSorter(CollectionSorterFactory.TYPE_DEFAULT);
 		}
-		filters.clear();
-		sorter = getCollectionSorter(CollectionSorterFactory.TYPE_DEFAULT);
 		requery();
 	}
 


### PR DESCRIPTION
This fixes an annoying bug I had.

1. Go to collection view
1. Add some filters
1. Select one of the games in the list
1. Press back

Previously, the filters of the list would be reset. Now they aren't - they remain as they were before selecting one of the games.

I'm not sure it's the best way to fix it, but it works for me.

