### PR TITLE
BggProvider.kt: Replace requireContext() by context!!

### DIFF
--- a/app/src/main/java/com/boardgamegeek/provider/BggProvider.kt
+++ b/app/src/main/java/com/boardgamegeek/provider/BggProvider.kt
@@ -2,7 +2,6 @@ package com.boardgamegeek.provider
 
 import android.content.ContentProvider
 import android.content.ContentValues
-import android.content.Context
 import android.content.UriMatcher
 import android.database.Cursor
 import android.net.Uri
@@ -25,25 +24,25 @@ class BggProvider : ContentProvider() {
     }
 
     override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor? {
-        return getProvider(uri)?.query(requireContext().contentResolver, openHelper.readableDatabase, uri, projection, selection, selectionArgs, sortOrder)?.also {
-            it.setNotificationUri(requireContext().contentResolver, uri)
+        return getProvider(uri)?.query(context!!.contentResolver, openHelper.readableDatabase, uri, projection, selection, selectionArgs, sortOrder)?.also {
+            it.setNotificationUri(context!!.contentResolver, uri)
         }
     }
 
     override fun insert(uri: Uri, values: ContentValues?): Uri? {
-        return getProvider(uri)?.insert(requireContext(), openHelper.writableDatabase, uri,
+        return getProvider(uri)?.insert(context!!, openHelper.writableDatabase, uri,
                 values ?: contentValuesOf())?.also {
             context?.contentResolver?.notifyChange(it, null)
         }
     }
 
     override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int {
-        return getProvider(uri)?.update(requireContext(), openHelper.writableDatabase, uri, values, selection, selectionArgs)
+        return getProvider(uri)?.update(context!!, openHelper.writableDatabase, uri, values, selection, selectionArgs)
                 ?: 0
     }
 
     override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int {
-        return getProvider(uri)?.delete(requireContext(),
+        return getProvider(uri)?.delete(context!!,
                 openHelper.writableDatabase,
                 uri, selection, selectionArgs)
                 ?: 0
@@ -51,7 +50,7 @@ class BggProvider : ContentProvider() {
 
     @Throws(FileNotFoundException::class)
     override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
-        return getProvider(uri)?.openFile(requireContext(), uri, mode)
+        return getProvider(uri)?.openFile(context!!, uri, mode)
     }
 
     private fun getProvider(uri: Uri): BaseProvider? {


### PR DESCRIPTION
The build the develop branch as-is fails with the exception shown below on my (HMD) Nokida 7 Plus running Android 10.

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.boardgamegeek, PID: 30735
    java.lang.NoSuchMethodError: No virtual method requireContext()Landroid/content/Context; in class Lcom/boardgamegeek/provider/BggProvider; or its super classes (declaration of 'com.boardgamegeek.provider.BggProvider' appears in /data/app/com.boardgamegeek-OSsvV3Z1KrlEY3riva2NfA==/base.apk!classes6.dex)
        at com.boardgamegeek.provider.BggProvider.query(BggProvider.kt:28)
        at android.content.ContentProvider.query(ContentProvider.java:1227)
        at android.content.ContentProvider.query(ContentProvider.java:1320)
        at android.content.ContentProvider$Transport.query(ContentProvider.java:280)
        at android.content.ContentResolver.query(ContentResolver.java:946)
```

As the implementation of requireContext() [1] is often limited to getting the context and throwing an exception when it is null, I replaced the calls to requireContext() to context!! calls.

There might be a real root cause to why the virtual method is missing, but this solution works for me.


[1] https://stackoverflow.com/questions/60402490/difference-between-getcontext-and-requirecontext-when-using-fragments


Signed-off-by: Elie De Brauwer <eliedebrauwer@gmail.com>