### PR TITLE
Fix #169: Unsuccessful post to BGG

### DIFF
--- a/app/src/main/java/com/boardgamegeek/io/Adapter.java
+++ b/app/src/main/java/com/boardgamegeek/io/Adapter.java
@@ -44,7 +44,7 @@ public class Adapter {
 			httpClient = HttpUtils.getHttpClientWithAuth(context);
 		}
 		return new Retrofit.Builder()
-			.baseUrl("https://www.boardgamegeek.com/")
+			.baseUrl("https://boardgamegeek.com/")
 			.client(httpClient);
 	}
 }


### PR DESCRIPTION
There was a change just two days ago to the XML API documentation dropping the leading "www" on the API request:
https://boardgamegeek.com/wiki/diff/BGG_XML_API2/2342384/2488801

This is in sync with the time that people started coming here to point out that they were getting errors on the app. I have not tested this change because I don't have the environment setup, but I feel like it might fix it.