### PR TITLE
Browser Link Handling and Suggested Player Count fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,18 @@
 	<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+	<!-- Declare intent filters to query for browser apps (required for Android 11+) -->
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="http" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https" />
+		</intent>
+	</queries>
+
 	<permission
 		android:name="com.boardgamegeek.permission.READ_BGG_PROVIDER"
 		android:protectionLevel="signature" />

--- a/app/src/main/java/com/boardgamegeek/extensions/LinkContext.kt
+++ b/app/src/main/java/com/boardgamegeek/extensions/LinkContext.kt
@@ -1,6 +1,5 @@
 package com.boardgamegeek.extensions
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -57,9 +56,11 @@ private fun Context?.link(link: Uri) {
     if (this == null) return
     val intent = Intent(Intent.ACTION_VIEW, link)
     if (this !is android.app.Activity) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    try {
+    
+    // Check if there's an app that can handle this intent
+    if (intent.resolveActivity(packageManager) != null) {
         startActivity(intent)
-    } catch (e: ActivityNotFoundException) {
+    } else {
         val message = "Can't figure out how to launch $link"
         Timber.w(message)
         toast(message)

--- a/app/src/main/java/com/boardgamegeek/ui/widget/GameRankRow.kt
+++ b/app/src/main/java/com/boardgamegeek/ui/widget/GameRankRow.kt
@@ -13,7 +13,7 @@ import java.text.DecimalFormat
 
 @SuppressLint("ViewConstructor")
 class GameRankRow(context: Context, isFamily: Boolean) : LinearLayout(context) {
-    private val binding = RowGameRankSubtypeBinding.inflate(LayoutInflater.from(context))
+    private val binding = RowGameRankSubtypeBinding.inflate(LayoutInflater.from(context), this, true)
 
     init {
         if (isFamily) {

--- a/app/src/main/java/com/boardgamegeek/ui/widget/PlayerNumberRow.kt
+++ b/app/src/main/java/com/boardgamegeek/ui/widget/PlayerNumberRow.kt
@@ -16,7 +16,7 @@ class PlayerNumberRow @JvmOverloads constructor(
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
-    private val binding = RowPollPlayersBinding.inflate(LayoutInflater.from(context))
+    private val binding = RowPollPlayersBinding.inflate(LayoutInflater.from(context), this, true)
     private var totalVoteCount: Int = 0
     private var bestVoteCount: Int = 0
     private var recommendedVoteCount: Int = 0

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.1'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.4.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'


### PR DESCRIPTION
This pull request tries to resolve the link issue on Android 11+. It turns out the `<queries>` are unavoidable. 

Additionally, it fixes two of my migration mistakes where 2 of the widgets weren't attached to the parent anymore. This fixes the "suggested player count" issue reported on the BGG forums.

**Intent handling and permissions:**

* Added `<queries>` section to `AndroidManifest.xml` to declare browser intent filters, ensuring compatibility with Android 11+ when querying for browser apps.
* Updated the `link` extension function to check if there is an app available to handle the intent before calling `startActivity`, improving error handling and preventing crashes if no suitable app is found.
* Removed the unnecessary import of `ActivityNotFoundException` from `LinkContext.kt` since explicit try/catch is no longer used.

**View binding fixes:**

* Fixed view binding inflation in `GameRankRow` and `PlayerNumberRow` by passing the parent view and setting `attachToParent` to `true`, ensuring proper layout behavior and avoiding potential bugs. [[1]](diffhunk://#diff-3125b11f89c9a0c739c44770098e43761ee72179025dc90fe81bf1a3b0641fb4L16-R16) [[2]](diffhunk://#diff-bbbca24131816d67ea73fb5b719bb6122eb37b408e0da90173353199c7bc8c55L19-R19)